### PR TITLE
Added rudimentary support for Calamity 2.1.2

### DIFF
--- a/SeldomDespArchipelago.cs
+++ b/SeldomDespArchipelago.cs
@@ -62,7 +62,7 @@ namespace SeldomDespArchipelago
         public static MethodInfo ravagerBodyOnKill = null;
         public static MethodInfo astrumDeusHeadOnKill = null;
         public static MethodInfo profanedGuardianCommanderOnKill = null;
-        public static MethodInfo bumblefuckOnKill = null;
+        public static MethodInfo dragonfollyOnKill = null;
         public static MethodInfo providenceOnKill = null;
         public static MethodInfo stormWeaverHeadOnKill = null;
         public static MethodInfo ceaselessVoidOnKill = null;
@@ -767,7 +767,7 @@ namespace SeldomDespArchipelago
                     case "RavagerBody": ravagerBodyOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "AstrumDeusHead": astrumDeusHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "ProfanedGuardianCommander": profanedGuardianCommanderOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
-                    case "Dragonfolly": bumblefuckOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
+                    case "Dragonfolly": dragonfollyOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Providence": providenceOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "StormWeaverHead": stormWeaverHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "CeaselessVoid": ceaselessVoidOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
@@ -806,7 +806,7 @@ namespace SeldomDespArchipelago
             onRavagerBodyOnKill += OnRavagerBodyOnKill;
             onAstrumDeusHeadOnKill += OnAstrumDeusHeadOnKill;
             onProfanedGuardianCommanderOnKill += OnProfanedGuardianCommanderOnKill;
-            onBumblefuckOnKill += OnBumblefuckOnKill;
+            onDragonfollyOnKill += OnDragonfollyOnKill;
             onProvidenceOnKill += OnProvidenceOnKill;
             onStormWeaverHeadOnKill += OnStormWeaverHeadOnKill;
             onCeaselessVoidOnKill += OnCeaselessVoidOnKill;
@@ -903,7 +903,7 @@ namespace SeldomDespArchipelago
             onRavagerBodyOnKill -= OnRavagerBodyOnKill;
             onAstrumDeusHeadOnKill -= OnAstrumDeusHeadOnKill;
             onProfanedGuardianCommanderOnKill -= OnProfanedGuardianCommanderOnKill;
-            onBumblefuckOnKill -= OnBumblefuckOnKill;
+            onDragonfollyOnKill -= OnDragonfollyOnKill;
             onProvidenceOnKill -= OnProvidenceOnKill;
             onStormWeaverHeadOnKill -= OnStormWeaverHeadOnKill;
             onCeaselessVoidOnKill -= OnCeaselessVoidOnKill;
@@ -1183,7 +1183,7 @@ namespace SeldomDespArchipelago
             else ModContent.GetInstance<ArchipelagoSystem>().QueueLocation("Profaned Guardians");
         }
 
-        void OnBumblefuckOnKill(OnKill orig, ModNPC self)
+        void OnDragonfollyOnKill(OnKill orig, ModNPC self)
         {
             if (temp) orig(self);
             else ModContent.GetInstance<ArchipelagoSystem>().QueueLocation("The Dragonfolly");
@@ -1420,9 +1420,9 @@ namespace SeldomDespArchipelago
             remove { }
         }
 
-        static event OnOnKill onBumblefuckOnKill
+        static event OnOnKill onDragonfollyOnKill
         {
-            add => MonoModHooks.Add(bumblefuckOnKill, value);
+            add => MonoModHooks.Add(dragonfollyOnKill, value);
             remove { }
         }
 

--- a/SeldomDespArchipelago.cs
+++ b/SeldomDespArchipelago.cs
@@ -757,7 +757,7 @@ namespace SeldomDespArchipelago
                         break;
                     case "AquaticScourgeHead": aquaticScourgeHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Mauler": maulerOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
-                    case "BrimstoneElemental": if (brimstoneElementalOnKill == null) brimstoneElementalOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
+                    case "BrimstoneElemental": brimstoneElementalOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Cryogen": cryogenOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "CalamitasClone": calamitasCloneOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "GreatSandShark": greatSandSharkOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;

--- a/SeldomDespArchipelago.cs
+++ b/SeldomDespArchipelago.cs
@@ -735,9 +735,9 @@ namespace SeldomDespArchipelago
             if (!ModLoader.HasMod("CalamityMod")) return;
             var calamity = ModLoader.GetMod("CalamityMod");
 
-            if (!calamity.Version.Equals(new Version(2, 0, 6, 2)))
+            if (!calamity.Version.Equals(new Version(2, 1, 2)))
             {
-                throw new Exception("Incompatible Calamity version. This is most likely because you are using the workshop version of Calamity.\nPlease reload with Calamity 2.0.6.2. For information on how to do that, see the pins in the Archipelago discord's #terraria channel");
+                throw new Exception("Incompatible Calamity version. This is most likely because you are using the workshop version of Calamity.\nPlease reload with Calamity 2.1.2. For information on how to do that, see the pins in the Archipelago discord's #terraria channel");
             }
 
             var calamityAssembly = calamity.GetType().Assembly;
@@ -757,7 +757,7 @@ namespace SeldomDespArchipelago
                         break;
                     case "AquaticScourgeHead": aquaticScourgeHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Mauler": maulerOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
-                    case "BrimstoneElemental": brimstoneElementalOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
+                    case "BrimstoneElemental": if (brimstoneElementalOnKill == null) brimstoneElementalOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Cryogen": cryogenOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "CalamitasClone": calamitasCloneOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "GreatSandShark": greatSandSharkOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
@@ -767,7 +767,7 @@ namespace SeldomDespArchipelago
                     case "RavagerBody": ravagerBodyOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "AstrumDeusHead": astrumDeusHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "ProfanedGuardianCommander": profanedGuardianCommanderOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
-                    case "Bumblefuck": bumblefuckOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
+                    case "Dragonfolly": bumblefuckOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "Providence": providenceOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "StormWeaverHead": stormWeaverHeadOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;
                     case "CeaselessVoid": ceaselessVoidOnKill = type.GetMethod("OnKill", BindingFlags.Instance | BindingFlags.Public); break;

--- a/Systems/ArchipelagoSystem.cs
+++ b/Systems/ArchipelagoSystem.cs
@@ -948,7 +948,7 @@ namespace SeldomDespArchipelago.Systems
             var location = session.session.Locations.GetLocationIdFromName(APWorldName, locationName);
             if (location == -1) return;
 
-            if (!session.session.Locations.AllMissingLocations.Contains(location))
+            if (session.session.Locations.AllLocationsChecked.Contains(location))
             {
                 Mod.Logger.Info($"[AP] Location {locationName} already collected.");
                 return;

--- a/Systems/ArchipelagoSystem.cs
+++ b/Systems/ArchipelagoSystem.cs
@@ -643,8 +643,8 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Cosmolight": ModContent.GetInstance<CalamitySystem>().GiveCosmolight(); break;
                 case "Reward: Diving Helmet": GiveItem(ItemID.DivingHelmet); break;
                 case "Reward: Jellyfish Necklace": GiveItem(ItemID.JellyfishNecklace); break;
-                case "Reward: Corrupt Flask": ModContent.GetInstance<CalamitySystem>().GiveCorruptFlask(); break;
-                case "Reward: Crimson Flask": ModContent.GetInstance<CalamitySystem>().GiveCrimsonFlask(); break;
+                case "Reward: Unholy Tonic": ModContent.GetInstance<CalamitySystem>().GiveCorruptFlask(); break;
+                case "Reward: Vicious Tonic": ModContent.GetInstance<CalamitySystem>().GiveCrimsonFlask(); break;
                 case "Reward: Craw Carapace": ModContent.GetInstance<CalamitySystem>().GiveCrawCarapace(); break;
                 case "Reward: Giant Shell": ModContent.GetInstance<CalamitySystem>().GiveGiantShell(); break;
                 case "Reward: Life Jelly": ModContent.GetInstance<CalamitySystem>().GiveLifeJelly(); break;
@@ -660,7 +660,7 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Rotten Dogtooth": ModContent.GetInstance<CalamitySystem>().GiveRottenDogtooth(); break;
                 case "Reward: Scuttler's Jewel": ModContent.GetInstance<CalamitySystem>().GiveScuttlersJewel(); break;
                 case "Reward: Unstable Granite Core": ModContent.GetInstance<CalamitySystem>().GiveUnstableGraniteCore(); break;
-                case "Reward: Amidias' Spark": ModContent.GetInstance<CalamitySystem>().GiveAmidiasSpark(); break;
+                case "Reward: Ilmeris' Spark": ModContent.GetInstance<CalamitySystem>().GiveAmidiasSpark(); break;
                 case "Reward: Ursa Sergeant": ModContent.GetInstance<CalamitySystem>().GiveUrsaSergeant(); break;
                 case "Reward: Trinket of Chi": ModContent.GetInstance<CalamitySystem>().GiveTrinketOfChi(); break;
                 case "Reward: The Transformer": ModContent.GetInstance<CalamitySystem>().GiveTheTransformer(); break;
@@ -676,7 +676,7 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Anechoic Plating": ModContent.GetInstance<CalamitySystem>().GiveAnechoicPlating(); break;
                 case "Reward: Iron Boots": ModContent.GetInstance<CalamitySystem>().GiveIronBoots(); break;
                 case "Reward: Sprit Glyph": ModContent.GetInstance<CalamitySystem>().GiveSpritGlyph(); break;
-                case "Reward: Abyssal Amulet": ModContent.GetInstance<CalamitySystem>().GiveAbyssalAmulet(); break;
+                case "Reward: Sea Spirit Amulet": ModContent.GetInstance<CalamitySystem>().GiveAbyssalAmulet(); break;
                 case "Reward: Life Crystal": GiveItem(ItemID.LifeCrystal); break;
                 case "Reward: Enchanted Sword": GiveItem(ItemID.EnchantedSword); break;
                 case "Reward: Starfury": GiveItem(ItemID.Starfury); break;

--- a/Systems/ArchipelagoSystem.cs
+++ b/Systems/ArchipelagoSystem.cs
@@ -643,8 +643,8 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Cosmolight": ModContent.GetInstance<CalamitySystem>().GiveCosmolight(); break;
                 case "Reward: Diving Helmet": GiveItem(ItemID.DivingHelmet); break;
                 case "Reward: Jellyfish Necklace": GiveItem(ItemID.JellyfishNecklace); break;
-                case "Reward: Unholy Tonic": ModContent.GetInstance<CalamitySystem>().GiveCorruptFlask(); break;
-                case "Reward: Vicious Tonic": ModContent.GetInstance<CalamitySystem>().GiveCrimsonFlask(); break;
+                case "Reward: Unholy Tonic": ModContent.GetInstance<CalamitySystem>().GiveUnholyTonic(); break;
+                case "Reward: Vicious Tonic": ModContent.GetInstance<CalamitySystem>().GiveViciousTonic(); break;
                 case "Reward: Craw Carapace": ModContent.GetInstance<CalamitySystem>().GiveCrawCarapace(); break;
                 case "Reward: Giant Shell": ModContent.GetInstance<CalamitySystem>().GiveGiantShell(); break;
                 case "Reward: Life Jelly": ModContent.GetInstance<CalamitySystem>().GiveLifeJelly(); break;
@@ -660,7 +660,7 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Rotten Dogtooth": ModContent.GetInstance<CalamitySystem>().GiveRottenDogtooth(); break;
                 case "Reward: Scuttler's Jewel": ModContent.GetInstance<CalamitySystem>().GiveScuttlersJewel(); break;
                 case "Reward: Unstable Granite Core": ModContent.GetInstance<CalamitySystem>().GiveUnstableGraniteCore(); break;
-                case "Reward: Ilmeris' Spark": ModContent.GetInstance<CalamitySystem>().GiveAmidiasSpark(); break;
+                case "Reward: Ilmeris' Spark": ModContent.GetInstance<CalamitySystem>().GiveIlmerisSpark(); break;
                 case "Reward: Ursa Sergeant": ModContent.GetInstance<CalamitySystem>().GiveUrsaSergeant(); break;
                 case "Reward: Trinket of Chi": ModContent.GetInstance<CalamitySystem>().GiveTrinketOfChi(); break;
                 case "Reward: The Transformer": ModContent.GetInstance<CalamitySystem>().GiveTheTransformer(); break;
@@ -676,7 +676,7 @@ namespace SeldomDespArchipelago.Systems
                 case "Reward: Anechoic Plating": ModContent.GetInstance<CalamitySystem>().GiveAnechoicPlating(); break;
                 case "Reward: Iron Boots": ModContent.GetInstance<CalamitySystem>().GiveIronBoots(); break;
                 case "Reward: Sprit Glyph": ModContent.GetInstance<CalamitySystem>().GiveSpritGlyph(); break;
-                case "Reward: Sea Spirit Amulet": ModContent.GetInstance<CalamitySystem>().GiveAbyssalAmulet(); break;
+                case "Reward: Sea Spirit Amulet": ModContent.GetInstance<CalamitySystem>().GiveSeaSpiritAmulet(); break;
                 case "Reward: Life Crystal": GiveItem(ItemID.LifeCrystal); break;
                 case "Reward: Enchanted Sword": GiveItem(ItemID.EnchantedSword); break;
                 case "Reward: Starfury": GiveItem(ItemID.Starfury); break;

--- a/Systems/ArchipelagoSystem.cs
+++ b/Systems/ArchipelagoSystem.cs
@@ -950,7 +950,7 @@ namespace SeldomDespArchipelago.Systems
 
             if (!session.session.Locations.AllMissingLocations.Contains(location))
             {
-                Chat($"Location {locationName} already collected.");
+                Mod.Logger.Info($"[AP] Location {locationName} already collected.");
                 return;
             }
             session.locationQueue.Add(session.session.Locations.ScoutLocationsAsync(new[] { location }));

--- a/Systems/CalamitySystem.cs
+++ b/Systems/CalamitySystem.cs
@@ -19,8 +19,8 @@ namespace SeldomDespArchipelago.Systems
 
         public void GiveCosmolight() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Tools.ClimateChange.Cosmolight>();
 
-        public void GiveCorruptFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.UnholyTonic>();
-        public void GiveCrimsonFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.ViciousTonic>();
+        public void GiveUnholyTonic() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.UnholyTonic>();
+        public void GiveViciousTonic() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.ViciousTonic>();
         public void GiveCrawCarapace() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.CrawCarapace>();
         public void GiveGiantShell() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.GiantShell>();
         public void GiveLifeJelly() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.LifeJelly>();
@@ -36,7 +36,7 @@ namespace SeldomDespArchipelago.Systems
         public void GiveRottenDogtooth() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.RottenDogtooth>();
         public void GiveScuttlersJewel() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.ScuttlersJewel>();
         public void GiveUnstableGraniteCore() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.UnstableGraniteCore>();
-        public void GiveAmidiasSpark() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.IlmerisSpark>();
+        public void GiveIlmerisSpark() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.IlmerisSpark>();
         public void GiveUrsaSergeant() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Fishing.AstralCatches.UrsaSergeant>();
         public void GiveTrinketOfChi() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.TrinketofChi>();
         public void GiveTheTransformer() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.TheTransformer>();
@@ -52,7 +52,7 @@ namespace SeldomDespArchipelago.Systems
         public void GiveAnechoicPlating() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.AnechoicPlating>();
         public void GiveIronBoots() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.IronBoots>();
         public void GiveSpritGlyph() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SpiritGlyph>();
-        public void GiveAbyssalAmulet() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SeaSpiritAmulet>();
+        public void GiveSeaSpiritAmulet() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SeaSpiritAmulet>();
 
         public bool ranBossRush = false;
 
@@ -209,7 +209,7 @@ namespace SeldomDespArchipelago.Systems
         public void CalamityOnKillRavager() => CalamityOnKill<CalamityMod.NPCs.Ravager.RavagerBody>(SeldomArchipelago.ravagerBodyOnKill);
         public void CalamityOnKillAstrumDeus() => CalamityOnKill<CalamityMod.NPCs.AstrumDeus.AstrumDeusHead>(SeldomArchipelago.astrumDeusHeadOnKill, new float[] { 3, 0, 0, 0 });
         public void CalamityOnKillProfanedGuardians() => CalamityOnKill<CalamityMod.NPCs.ProfanedGuardians.ProfanedGuardianCommander>(SeldomArchipelago.profanedGuardianCommanderOnKill);
-        public void CalamityOnKillTheDragonfolly() => CalamityOnKill<CalamityMod.NPCs.Bumblebirb.Dragonfolly>(SeldomArchipelago.bumblefuckOnKill);
+        public void CalamityOnKillTheDragonfolly() => CalamityOnKill<CalamityMod.NPCs.Bumblebirb.Dragonfolly>(SeldomArchipelago.dragonfollyOnKill);
         public void CalamityOnKillProvidenceTheProfanedGoddess() => CalamityOnKill<CalamityMod.NPCs.Providence.Providence>(SeldomArchipelago.providenceOnKill);
         public void CalamityOnKillStormWeaver() => CalamityOnKill<CalamityMod.NPCs.StormWeaver.StormWeaverHead>(SeldomArchipelago.stormWeaverHeadOnKill);
         public void CalamityOnKillCeaselessVoid() => CalamityOnKill<CalamityMod.NPCs.CeaselessVoid.CeaselessVoid>(SeldomArchipelago.ceaselessVoidOnKill);

--- a/Systems/CalamitySystem.cs
+++ b/Systems/CalamitySystem.cs
@@ -54,9 +54,15 @@ namespace SeldomDespArchipelago.Systems
         public void GiveSpritGlyph() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SpiritGlyph>();
         public void GiveAbyssalAmulet() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SeaSpiritAmulet>();
 
+        public bool ranBossRush = false;
+
         public void CalamityPostUpdateWorld()
         {
-            if (CalamityMod.DownedBossSystem.downedBossRush) ModContent.GetInstance<ArchipelagoSystem>().QueueLocation("Boss Rush");
+            if (CalamityMod.DownedBossSystem.downedBossRush && !ranBossRush) 
+            {
+                ModContent.GetInstance<ArchipelagoSystem>().QueueLocation("Boss Rush");
+                ranBossRush = true;
+            }
         }
 
         public bool CheckCalamityFlag(string flag) => flag switch

--- a/Systems/CalamitySystem.cs
+++ b/Systems/CalamitySystem.cs
@@ -19,8 +19,8 @@ namespace SeldomDespArchipelago.Systems
 
         public void GiveCosmolight() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Tools.ClimateChange.Cosmolight>();
 
-        public void GiveCorruptFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.CorruptFlask>();
-        public void GiveCrimsonFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.CrimsonFlask>();
+        public void GiveCorruptFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.UnholyTonic>();
+        public void GiveCrimsonFlask() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.ViciousTonic>();
         public void GiveCrawCarapace() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.CrawCarapace>();
         public void GiveGiantShell() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.GiantShell>();
         public void GiveLifeJelly() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.LifeJelly>();
@@ -36,7 +36,7 @@ namespace SeldomDespArchipelago.Systems
         public void GiveRottenDogtooth() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.RottenDogtooth>();
         public void GiveScuttlersJewel() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.ScuttlersJewel>();
         public void GiveUnstableGraniteCore() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.UnstableGraniteCore>();
-        public void GiveAmidiasSpark() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.AmidiasSpark>();
+        public void GiveAmidiasSpark() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.IlmerisSpark>();
         public void GiveUrsaSergeant() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Fishing.AstralCatches.UrsaSergeant>();
         public void GiveTrinketOfChi() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.TrinketofChi>();
         public void GiveTheTransformer() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.TheTransformer>();
@@ -52,7 +52,7 @@ namespace SeldomDespArchipelago.Systems
         public void GiveAnechoicPlating() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.AnechoicPlating>();
         public void GiveIronBoots() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.IronBoots>();
         public void GiveSpritGlyph() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SpiritGlyph>();
-        public void GiveAbyssalAmulet() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.AbyssalAmulet>();
+        public void GiveAbyssalAmulet() => ModContent.GetInstance<ArchipelagoSystem>().GiveItem<CalamityMod.Items.Accessories.SeaSpiritAmulet>();
 
         public void CalamityPostUpdateWorld()
         {
@@ -107,7 +107,7 @@ namespace SeldomDespArchipelago.Systems
 
         public void CalamityStartHardmode()
         {
-            if (CalamityConfig.Instance.EarlyHardmodeProgressionRework && NPC.downedMechBoss1 && NPC.downedMechBoss2 && NPC.downedMechBoss3) SpawnMechOres();
+            if (CalamityServerConfig.Instance.EarlyHardmodeProgressionRework && NPC.downedMechBoss1 && NPC.downedMechBoss2 && NPC.downedMechBoss3) SpawnMechOres();
         }
 
         public void VanillaBossKilled(int boss)
@@ -203,7 +203,7 @@ namespace SeldomDespArchipelago.Systems
         public void CalamityOnKillRavager() => CalamityOnKill<CalamityMod.NPCs.Ravager.RavagerBody>(SeldomArchipelago.ravagerBodyOnKill);
         public void CalamityOnKillAstrumDeus() => CalamityOnKill<CalamityMod.NPCs.AstrumDeus.AstrumDeusHead>(SeldomArchipelago.astrumDeusHeadOnKill, new float[] { 3, 0, 0, 0 });
         public void CalamityOnKillProfanedGuardians() => CalamityOnKill<CalamityMod.NPCs.ProfanedGuardians.ProfanedGuardianCommander>(SeldomArchipelago.profanedGuardianCommanderOnKill);
-        public void CalamityOnKillTheDragonfolly() => CalamityOnKill<CalamityMod.NPCs.Bumblebirb.Bumblefuck>(SeldomArchipelago.bumblefuckOnKill);
+        public void CalamityOnKillTheDragonfolly() => CalamityOnKill<CalamityMod.NPCs.Bumblebirb.Dragonfolly>(SeldomArchipelago.bumblefuckOnKill);
         public void CalamityOnKillProvidenceTheProfanedGoddess() => CalamityOnKill<CalamityMod.NPCs.Providence.Providence>(SeldomArchipelago.providenceOnKill);
         public void CalamityOnKillStormWeaver() => CalamityOnKill<CalamityMod.NPCs.StormWeaver.StormWeaverHead>(SeldomArchipelago.stormWeaverHeadOnKill);
         public void CalamityOnKillCeaselessVoid() => CalamityOnKill<CalamityMod.NPCs.CeaselessVoid.CeaselessVoid>(SeldomArchipelago.ceaselessVoidOnKill);
@@ -218,14 +218,14 @@ namespace SeldomDespArchipelago.Systems
 
         public void SpawnHardOres()
         {
-            if (!CalamityMod.CalamityConfig.Instance.EarlyHardmodeProgressionRework) return;
+            if (!CalamityMod.CalamityServerConfig.Instance.EarlyHardmodeProgressionRework) return;
             CalamityMod.CalamityUtils.SpawnOre(107, 0.00012, 0.45f, 0.7f, 3, 8, Array.Empty<int>());
             CalamityMod.CalamityUtils.SpawnOre(221, 0.00012, 0.45f, 0.7f, 3, 8, Array.Empty<int>());
         }
 
         public void SpawnMechOres()
         {
-            if (!CalamityMod.CalamityConfig.Instance.EarlyHardmodeProgressionRework) return;
+            if (!CalamityMod.CalamityServerConfig.Instance.EarlyHardmodeProgressionRework) return;
             typeof(CalamityMod.NPCs.CalamityGlobalNPC).GetMethod("SpawnMechBossHardmodeOres", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(new CalamityMod.NPCs.CalamityGlobalNPC(), null);
         }
 

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Archipelago Randomizer (Desp's Beta)
 author = Desp
-version = 2.0.3.1
+version = 2.1.0.1
 homepage = https://github.com/desperandos101/SeldomArchipelago/tree/release
 includeSource = true
 dllReferences = Archipelago.MultiClient.Net, Newtonsoft.Json

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Archipelago Randomizer (Desp's Beta)
 author = Desp
-version = 2.1.0.1
+version = 2.0.3.1
 homepage = https://github.com/desperandos101/SeldomArchipelago/tree/release
 includeSource = true
 dllReferences = Archipelago.MultiClient.Net, Newtonsoft.Json


### PR DESCRIPTION
Fixed Issues arising from Calamity Renaming classes internally. Fixed an Issue where Brimstone Elemental would not be able to load the OnKill Method due to the chosen OnKill Method being from the Friendly NPC, which does not have an OnKill Method

- As per request of you I have opened the Pull request here. These changes are only to get the mod to compile, this is not tested. Any additions to Calamity are not considered in here.