### PR TITLE
Fixed the Modded NPCs not moving inbug

### DIFF
--- a/SeldomDespArchipelago.cs
+++ b/SeldomDespArchipelago.cs
@@ -225,6 +225,15 @@ namespace SeldomDespArchipelago
                                     archipelagoSystem.world.ghostNPCqueue.Enqueue(type);
                             }
                     }
+                    // Check Modded NPCs
+                    for (int i = NPCID.Count; i < NPCLoader.NPCCount; i++)
+                    {
+                        ModNPC modNPC = NPCLoader.GetNPC(i);
+                        if (modNPC.CanTownNPCSpawn(i))
+                        {
+                            Main.townNPCCanSpawn[i] = true;
+                        }
+                    }
                     // Block Duplicate Normal NPCs
                     foreach (int type in existingTownTypes)
                     {


### PR DESCRIPTION
Original problem: The code only ever checks for vanilla NPCs at runtime, as the code overwrites the normal NPCSpawn logic.

Using NPCLoader.NPCCount gets all the modded npcs aswell and starting after NPCID.Count leaves the vanilla NPCs alone :D